### PR TITLE
Remove polyfillio

### DIFF
--- a/themes/the-equity-fund/includes/Managers/ThemeManager.php
+++ b/themes/the-equity-fund/includes/Managers/ThemeManager.php
@@ -58,8 +58,6 @@ class ThemeManager {
 		// Remove default Gutenberg CSS.
 		wp_deregister_style( 'wp-block-library' );
 
-		wp_register_script( 'polyfill', 'https://polyfill.io/v3/polyfill.min.js?features=fetch%2CArray.from%2CElement.prototype.append', array(), THE_EQUITY_FUND_THEME_VERSION, true );
-
 		wp_enqueue_script( 'vendor', THE_EQUITY_FUND_THEME_URL . '/dist/static/vendor.js', array(), THE_EQUITY_FUND_THEME_VERSION, true );
 
 		// Enqueue custom JS file, with cache busting.


### PR DESCRIPTION
## Changes

Removes polyfill.io request. @gvjacob do you forsee any issues this would cause with any js on the site? A quick scan says no - the three polfill targets are all well supported and it doesn't even look like `fetch` or `Element.append` are being used anywhere - but wanted to double check.