### PR TITLE
Fix: Remove lazyload

### DIFF
--- a/themes/the-equity-fund/static/js/app.js
+++ b/themes/the-equity-fund/static/js/app.js
@@ -1,5 +1,5 @@
-import 'lazysizes';
-import 'lazysizes/plugins/unveilhooks/ls.unveilhooks';
+// import 'lazysizes';
+// import 'lazysizes/plugins/unveilhooks/ls.unveilhooks';
 
 import Alpine from 'alpinejs';
 import focus from '@alpinejs/focus';

--- a/themes/the-equity-fund/templates/components/lazy-img.twig
+++ b/themes/the-equity-fund/templates/components/lazy-img.twig
@@ -31,8 +31,6 @@
   } %}
 #}
 
-{% set caption = caption ?? img.caption|replace({ '"': '&quot;' })|e('html') %}
-{% set credit = credit ?? img.credit|replace({ '"': '&quot;' })|e('html') %}
 {% set aspectRatio = aspectRatio ?? false %}
 
 {# calculate aspect ratio using image sizes #}
@@ -57,12 +55,11 @@
 <div class="relative bg-background {{ class }}">
   <span class="block w-full" style="padding-top: {{ padding }}"></span>
   <img
-    class="lazyload absolute inset-0 w-full h-full object-cover opacity-0 transition-all [&.lazyloaded]:opacity-100"
-    data-srcset="{{ img.srcset }}"
-    data-src="{{ img.src }}"
-    data-sizes="auto"
+    class="absolute inset-0 w-full h-full object-cover"
+    src="{{ img.src }}"
+    srcset="{{ img.srcset }}"
+    sizes="auto"
     {% if img.alt %}alt="{{ img.alt }}"{% endif %}
-    data-caption="{{ caption }}"
-    data-credit="{{ credit }}"
+    loading="lazy"
   />
 </div>


### PR DESCRIPTION
## Changes
- Remove lazyload from images
- Avoid importing lazysizes library

## How To Test
Just make sure the site's images load fine still

## TODOs:

- [ ] Updated editor documentation
- [ ] Updated Trello status

### Optional:

- [ ] <a href="https://cpi-pa11y.herokuapp.com/" target="_blank">Run and add accessibility test</a>
- [ ] Add Cypress interaction test
