### PR TITLE
Quickfix: Remove polyfill from app.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@upstatement/the-equity-fund",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@upstatement/the-equity-fund",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@alpinejs/focus": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstatement/the-equity-fund",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "author": "Upstatement",
   "repository": "",

--- a/themes/the-equity-fund/includes/Managers/ThemeManager.php
+++ b/themes/the-equity-fund/includes/Managers/ThemeManager.php
@@ -61,7 +61,7 @@ class ThemeManager {
 		wp_enqueue_script( 'vendor', THE_EQUITY_FUND_THEME_URL . '/dist/static/vendor.js', array(), THE_EQUITY_FUND_THEME_VERSION, true );
 
 		// Enqueue custom JS file, with cache busting.
-		wp_enqueue_script( 'script.js', THE_EQUITY_FUND_THEME_URL . '/dist/static/app.js', array( 'polyfill' ), THE_EQUITY_FUND_THEME_VERSION, true );
+		wp_enqueue_script( 'script.js', THE_EQUITY_FUND_THEME_URL . '/dist/static/app.js', array(), THE_EQUITY_FUND_THEME_VERSION, true );
 	}
 
 	/**

--- a/themes/the-equity-fund/style.css
+++ b/themes/the-equity-fund/style.css
@@ -2,5 +2,5 @@
  * Theme Name: The Equity Fund
  * Description:
  * Author: Upstatement
- * Version: 1.1.0
+ * Version: 1.1.1
  */


### PR DESCRIPTION
## Changes
App.js isn't loading because polyfill couldn't be found. This PR removes that polyfill dependency

## How To Test

(necessary config changes)

(how to access the new / changed functionality -- fixtures, URLs)

## TODOs:

- [ ] Updated editor documentation
- [ ] Updated Trello status

### Optional:

- [ ] <a href="https://cpi-pa11y.herokuapp.com/" target="_blank">Run and add accessibility test</a>
- [ ] Add Cypress interaction test
