### PR TITLE
EF-29 - add margin to bottom line of homepage title

### DIFF
--- a/themes/the-equity-fund/templates/components/toppers/homepage-topper.twig
+++ b/themes/the-equity-fund/templates/components/toppers/homepage-topper.twig
@@ -1,8 +1,8 @@
 <header class="palette-lavender bg-background px-site-padding pb-12 md:pb-16 pt-topper-margin size-{{ size|default('large') }}">
   <div class="flex items-center justify-center mt-[2vw]">
     <h1 class="text-foreground text-center uppercase leading-[0.8] {{ size == 'small' ? 'text-[20vw]'}} {{ size == 'medium' ? 'text-[25vw]'}} {{ size == 'large' ? 'text-[35vw]' }}">
-      <span class="font-display font-medium whitespace-nowrap">{{ headline.first_line }}</span><br>
-      <span class="font-display font-medium whitespace-nowrap">{{ headline.second_line }} </span>
+      <span class="font-display font-medium whitespace-nowrap">{{ headline.first_line }}</span>
+      <span class="relative z-10 inline-block font-display font-medium whitespace-nowrap mt-[15vw]">{{ headline.second_line }} </span>
     </h1>
 
     {% if image %}


### PR DESCRIPTION
## Changes

increase space between the lines of homepage heading title
set z-index to the second line so it overlaps the image

![image](https://github.com/user-attachments/assets/a12fc5d7-ef37-4743-8f5f-3c550ceadc48)

## How To Test

check the homepage
