### PR TITLE
EF-78 - add video option for homepage topper

### DIFF
--- a/web/wp-content/themes/the-equity-fund/acf-json/group_67003853e9700.json
+++ b/web/wp-content/themes/the-equity-fund/acf-json/group_67003853e9700.json
@@ -94,6 +94,27 @@
       "placeholder": "",
       "prepend": "",
       "append": ""
+    },
+    {
+      "key": "field_69895448f84eb",
+      "label": "Video",
+      "name": "video",
+      "aria-label": "",
+      "type": "file",
+      "instructions": "Optional. If provided - the video will be displayed instead of the image.",
+      "required": 0,
+      "conditional_logic": 0,
+      "wrapper": {
+        "width": "",
+        "class": "",
+        "id": ""
+      },
+      "return_format": "url",
+      "library": "all",
+      "min_size": "",
+      "max_size": "",
+      "mime_types": "",
+      "allow_in_bindings": 0
     }
   ],
   "location": [
@@ -115,5 +136,5 @@
   "description": "",
   "show_in_rest": 0,
   "display_title": "",
-  "modified": 1769060313
+  "modified": 1770620352
 }

--- a/web/wp-content/themes/the-equity-fund/static/js/app.js
+++ b/web/wp-content/themes/the-equity-fund/static/js/app.js
@@ -20,4 +20,26 @@ onDocumentReady(() => {
   });
 
   Alpine.start();
+
+  /**
+   * Ambient Hero Video (click = pause/play)
+   */
+  const ambientVideos = document.querySelectorAll('[data-ambient-video]');
+
+  ambientVideos.forEach(video => {
+    video.addEventListener('click', e => {
+      e.preventDefault();
+
+      if (video.paused) {
+        video.play();
+      } else {
+        video.pause();
+      }
+    });
+
+    // Disable double-click seek behavior
+    video.addEventListener('dblclick', e => {
+      e.preventDefault();
+    });
+  });
 });

--- a/web/wp-content/themes/the-equity-fund/templates/components/toppers/homepage-topper.twig
+++ b/web/wp-content/themes/the-equity-fund/templates/components/toppers/homepage-topper.twig
@@ -3,24 +3,45 @@
 
     <figure class="w-full xl:w-[80%] mx-auto relative">
 
-      {# MOBILE #}
-      {% if image_mobile %}
-        <div class="[display:block] md:[display:none] w-full">
-          {% include 'templates/components/lazy-img.twig' with {
-            img: get_image(image_mobile),
-            aspectRatio: 'horizontal',
-          } %}
-        </div>
-      {% endif %}
+      {% if hero_video %}
 
-      {# DESKTOP #}
-      {% if image %}
-        <div class="[display:none] md:[display:block] w-full">
-          {% include 'templates/components/lazy-img.twig' with {
-            img: get_image(image),
-            aspectRatio: 'wide',
-          } %}
+        <div class="w-full aspect-[16/9] overflow-hidden">
+
+          <video
+            class="w-full h-full object-cover cursor-pointer"
+            autoplay
+            muted
+            loop
+            playsinline
+            preload="metadata"
+            data-ambient-video
+          >
+            <source src="{{ hero_video }}" type="video/mp4">
+          </video>
+
         </div>
+
+      {% else %}
+
+        {# MOBILE #}
+        {% if image_mobile %}
+          <div class="[display:block] md:[display:none] w-full">
+            {% include 'templates/components/lazy-img.twig' with {
+              img: get_image(image_mobile),
+              aspectRatio: 'horizontal',
+            } %}
+          </div>
+        {% endif %}
+
+        {# DESKTOP #}
+        {% if image %}
+          <div class="[display:none] md:[display:block] w-full">
+            {% include 'templates/components/lazy-img.twig' with {
+              img: get_image(image),
+              aspectRatio: 'wide',
+            } %}
+          </div>
+        {% endif %}
       {% endif %}
 
     </figure>

--- a/web/wp-content/themes/the-equity-fund/templates/pages/page--homepage.twig
+++ b/web/wp-content/themes/the-equity-fund/templates/pages/page--homepage.twig
@@ -7,7 +7,8 @@
     headline: page.meta('headline'),
     image: page.meta('image'),
     image_mobile: page.meta('image_mobile') ?: page.meta('image'),
-    introduction: page.meta('introduction')
+    introduction: page.meta('introduction'),
+    hero_video: page.meta('video')
   } %}
 
   <div class="gutenberg rich-text">


### PR DESCRIPTION
## Changes

- add video option for homepage topper
- changes to acf group and the template for the homepage topper

Upload a video to the field and it will be shown on the homepage instead of the image